### PR TITLE
WindupProjectile: remove redundant currentVelocity

### DIFF
--- a/Assets/Scripts/WindupProjectile.cs
+++ b/Assets/Scripts/WindupProjectile.cs
@@ -7,7 +7,7 @@ public class WindupProjectile : Projectile
 
 
      [HideInInspector]
-     public Vector2 maxVelocity, currentVelocity;
+     public Vector2 maxVelocity;
      private float speedBoost, temp;
 
      public void Start()


### PR DESCRIPTION
The parent class already had a variable named this.

This fixes an exception.
