### PR TITLE
RoomUnlock.cs: handle missing enemies

### DIFF
--- a/Assets/Scripts/RoomUnlock.cs
+++ b/Assets/Scripts/RoomUnlock.cs
@@ -20,6 +20,8 @@ public class RoomUnlock : MonoBehaviour
           isActive = false;
           hasBeenActivated = false;
 
+          filter();
+
           foreach (Door door in doors)
           {
                door.OpenDoor();
@@ -31,6 +33,28 @@ public class RoomUnlock : MonoBehaviour
           foreach (GameObject reward in rewards)
           {
                reward.SetActive(false);
+          }
+     }
+
+     private void filter()
+     {
+          List<GameObject> existing = new List<GameObject>();
+          
+          foreach (GameObject enemy in enemies)
+          {
+               if (enemy)
+               {
+                    existing.Add(enemy);
+               }
+          }
+          if (enemies.Count != existing.Count)
+          {
+               string name = this.gameObject.name;
+               int difference = enemies.Count - existing.Count;
+               Debug.Log("Room \"" + name + "\" is missing " + difference.ToString() +
+                         " enemies in its Enemies list.");
+
+               enemies = existing;
           }
      }
 


### PR DESCRIPTION
Handle the situation where a room has an enemies array that is too big and it has missing Enemies. When this occurs, ignore the missing Enemy elements.  Print a log message to the Unity console when this happens.

Fixes an exception.
